### PR TITLE
[49] Plans can be filtered by branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 
 # Version file
 _version
+.tags

--- a/git_plan/cli/commands/list.py
+++ b/git_plan/cli/commands/list.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser
 from typing import Any
 
 from git_plan.cli.commands.command import Command
+from git_plan.service.git import GitService
 from git_plan.service.plan import PlanService
 from git_plan.util.decorators import requires_initialized
 
@@ -16,14 +17,23 @@ class List(Command):
 
     subcommand = 'list'
 
-    def __init__(self, plan_service: PlanService, **kwargs):
+    def __init__(self, plan_service: PlanService, git_service: GitService, **kwargs):
         super().__init__(**kwargs)
         assert plan_service, "Plan service not injected"
         self._plan_service = plan_service
+        self._git = git_service
 
-    def command(self, *, long: bool = False, **kwargs):  # pylint: disable=arguments-differ
+    def command(self, *, long: bool = False, branch: str = None, **kwargs):  # pylint: disable=arguments-differ
         """List the planned commits"""
-        commits = self._plan_service.get_commits(self._project)
+        if not branch:
+            branch = self._git.get_current_branch()
+        elif branch == "all":
+            branch = None
+
+        branch_display = branch if branch else "all branches"
+        self._ui.print(f"Plans for [bold]{branch_display}[/bold]\n")
+        commits = self._plan_service.get_commits(self._project, branch=branch)
+
         if len(commits) == 0:
             self._ui.bold("No commit plans.")
             return
@@ -33,4 +43,5 @@ class List(Command):
 
     def register_subparser(self, subparsers: Any):
         parser: ArgumentParser = subparsers.add_parser(List.subcommand, help='List existing commit plans.')
-        parser.add_argument('--long', dest='long', action='store_true')
+        parser.add_argument('-l', '--long', dest='long', action='store_true')
+        parser.add_argument('-b', '--branch', dest='branch', help="Filter plans for a specific branch")

--- a/git_plan/containers.py
+++ b/git_plan/containers.py
@@ -3,7 +3,7 @@
 @author Rory Byrne <rory@rory.bio>
 """
 # pylint: disable=no-member
-from dependency_injector import providers, containers
+from dependency_injector import containers, providers
 
 from git_plan.cli.cli import CLI
 from git_plan.cli.commands.add import Add
@@ -61,6 +61,7 @@ class Commands(containers.DeclarativeContainer):
         List,
         plan_service=services.plan_service,
         ui_service=services.ui_service,
+        git_service=services.git_service,
         project=core.project
     )
     add_command = providers.Singleton(

--- a/git_plan/exceptions.py
+++ b/git_plan/exceptions.py
@@ -27,6 +27,9 @@ class CommitAbandoned(GitPlanException):
 class PlanEmpty(GitPlanException):
     """The commit plan was empty"""
 
+class GitException(GitPlanException):
+    """Base class for git-related exceptions"""
 
-class NotAGitRepository(GitPlanException):
+
+class NotAGitRepository(GitException):
     """The current project is not a git repository"""

--- a/git_plan/model/commit.py
+++ b/git_plan/model/commit.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from git_plan.exceptions import ProjectNotInitialized, GitPlanException
+from git_plan.exceptions import GitPlanException, ProjectNotInitialized
 from git_plan.model.project import Project
 
 COMMIT_FILE_EXT = '.txt'
@@ -91,10 +91,10 @@ class Commit:
             raise ProjectNotInitialized()
 
         commit_dict = {
-            "branch": self.branch,
+            "branch": self.branch.strip(),
             'message': {
-                "headline": self.message.headline,
-                "body": self.message.body
+                "headline": self.message.headline.strip(),
+                "body": self.message.body.strip()
             },
         }
 

--- a/git_plan/service/git.py
+++ b/git_plan/service/git.py
@@ -3,6 +3,7 @@
 Author: Rory Byrne <rory@rory.bio>
 """
 import subprocess
+from typing import List, Optional
 
 from git_plan.exceptions import CommitAbandoned, GitException
 from git_plan.model.commit import Commit
@@ -11,42 +12,50 @@ from git_plan.model.commit import Commit
 class GitService:
     """Interface to git functionality"""
 
+    COMMIT = 'git commit -e -m'
+    HAS_STAGED = 'git diff --staged --quiet'
+    GET_BRANCH = 'git branch --show-current'
+
     def __init__(self):
         pass
 
-    @staticmethod
-    def commit(commit: Commit):
+    def commit(self, commit: Commit):
         """Runs git commit with the given commit-plan as a template"""
-        cmd = 'git commit -e -m'.split(' ')
+        cmd = self.COMMIT.split(' ')
         cmd.append(str(commit.message))
 
         try:
-            subprocess.run(cmd, check=True)
+            self._run_command(cmd, capture_output=False)
         except subprocess.CalledProcessError as e:
             raise CommitAbandoned() from e
 
-    @staticmethod
-    def has_staged_files() -> bool:
+    def has_staged_files(self) -> bool:
         """Returns True if there are staged files, and False otherwise"""
-        cmd = 'git diff --staged --quiet'.split(' ')
+        cmd = self.HAS_STAGED.split(' ')
 
         try:
-            subprocess.run(cmd, check=True)
+            self._run_command(cmd)
             return False
         except subprocess.CalledProcessError:
             return True
 
-    @staticmethod
-    def get_current_branch():
+    def get_current_branch(self):
         """Gets the current branch via git"""
-        cmd = 'git branch --show-current'.split(' ')
+        cmd = self.GET_BRANCH.split(' ')
 
         try:
-            result = subprocess.run(cmd, capture_output=True, check=True)
-            branch = result.stdout.decode('utf-8')
+            branch = self._run_command(cmd)
             if not branch or branch == '':
                 raise GitException(f'Invalid branch: "{branch}"')
 
             return branch.strip()
         except subprocess.CalledProcessError as e:
             raise GitException('Failed to get current git branch') from e
+
+    @staticmethod
+    def _run_command(cmd: List[str], capture_output: bool = True) -> Optional[str]:
+        result = subprocess.run(cmd, capture_output=capture_output, check=True)
+        if result.stdout:
+            return result.stdout.decode()
+
+        return None

--- a/git_plan/service/plan.py
+++ b/git_plan/service/plan.py
@@ -60,13 +60,13 @@ class PlanService:
         return any(project.plan_dir.iterdir())  # False if it cannot iterate at least once
 
     @requires_initialized
-    def get_commits(self, project: Project) -> List[Commit]:
+    def get_commits(self, project: Project, branch: str = None) -> List[Commit]:
         """Print the status of the plan
 
         Raises:
             RuntimeError:   Commit file not found
         """
-        return self._fetch_commits(project)
+        return self._fetch_commits(project, branch=branch)
 
     # Private #############
 
@@ -99,12 +99,15 @@ class PlanService:
 
             return CommitMessage.from_string(processed_input)
 
-    def _fetch_commits(self, project: Project) -> List['Commit']:
+    def _fetch_commits(self, project: Project, branch: str = None) -> List['Commit']:
         if not self.has_commits(project):
             return []
 
         commit_files = project.plan_dir.iterdir()
-        commits = [Commit.from_file(f, project) for f in commit_files]
+        commits: List[Commit] = [Commit.from_file(f, project) for f in commit_files]
+        if branch:
+            # .strip() for backawrds compatibility
+            commits = [commit for commit in commits if commit.branch.strip() == branch]
 
         return commits
 

--- a/git_plan/service/ui.py
+++ b/git_plan/service/ui.py
@@ -5,19 +5,21 @@ Author: Rory Byrne <rory@rory.bio>
 from typing import List
 
 import inquirer
-from rich import print
+from rich import print as rich_print
 
 from git_plan.model.commit import Commit
 
 
 class UIService:
+    """Functionality for rendering in the terminal"""
 
     @staticmethod
     def choose_commit(commits: List[Commit], message: str):
         """Choose from a set of tasks"""
         if len(commits) == 0:
             raise RuntimeError("Cannot choose from an empty list of commits.")
-        elif len(commits) == 1:
+
+        if len(commits) == 1:
             return commits[0]
 
         options = [
@@ -34,6 +36,7 @@ class UIService:
 
     @staticmethod
     def confirm(message: str) -> bool:
+        """Ask the user for confirmation"""
         key = 'confirm'
         questions = [inquirer.Confirm(key, message=message)]
 
@@ -41,9 +44,14 @@ class UIService:
 
         return answers[key]
 
+    def bold(self, message: str):
+        """Print a bolded message"""
+        self.print(f'[bold]{message}[/bold]')
+
     @staticmethod
-    def bold(message: str):
-        print(f'[bold]{message}[/bold]')
+    def print(message: str):
+        """Print a message to the terminal"""
+        rich_print(message)
 
     def render_commits(self, commits: List[Commit], headline_only=True):
         """Renders a list of commits in pretty print"""
@@ -52,13 +60,12 @@ class UIService:
             if idx < len(commits) - 1:
                 print('')
 
-    @staticmethod
-    def _render_commit(commit: Commit, tag: str, headline_only):
+    def _render_commit(self, commit: Commit, tag: str, headline_only):
         if headline_only:
-            print(f'[bold][{tag}][/bold] {commit.message.headline}')
+            self.print(f'[bold][{tag}][/bold] {commit.message.headline}')
         else:
-            print(f'[bold][[magenta]{tag}[/magenta]][/bold] on {commit.branch}\n')
-            print(f'    {commit.message.headline}\n')
+            self.print(f'[bold][[magenta]{tag}[/magenta]][/bold] on {commit.branch}\n')
+            self.print(f'    {commit.message.headline}\n')
             body_lines = commit.message.body.split('\n')
             for line in body_lines:
-                print(f'    {line}')
+                self.print(f'    {line}')

--- a/git_plan/util/decorators.py
+++ b/git_plan/util/decorators.py
@@ -3,14 +3,12 @@
 Author: Rory Byrne <rory@rory.bio>
 """
 from functools import wraps
-from typing import Callable, Union, Type
+from typing import Callable, Type, Union
 
 from git_plan.cli.commands.command import Command
 from git_plan.exceptions import ProjectNotInitialized
 from git_plan.model.commit import Commit
 from git_plan.model.project import Project
-
-CanCheckInitialized = Union[Project, Commit]
 
 
 def requires_initialized(ref: Union[Type[Command], Callable]):
@@ -39,7 +37,7 @@ def requires_initialized(ref: Union[Type[Command], Callable]):
 
         if is_initialized:
             return ref(*args, **kwargs)
-        else:
-            raise ProjectNotInitialized()
+
+        raise ProjectNotInitialized()
 
     return wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [tool.pylint.MASTER]
 extension-pkg-whitelist = "dependency_injector"
 generated-members = "dependency_inector.*, subcommand, wire"
-good-names = "id, fp"
+good-names = "id, fp, e"
 max-line-length = 120
+
+[tool.isort]
+known_first_party = ['git_plan']

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
 tox==3.23.0
 pre-commit==2.11.1
+pytest==6.2.2

--- a/tests/service/test_git_service.py
+++ b/tests/service/test_git_service.py
@@ -1,0 +1,38 @@
+from subprocess import CalledProcessError
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from git_plan.exceptions import CommitAbandoned, GitException
+from git_plan.model.commit import Commit
+from git_plan.service.git import GitService
+
+
+class TestGitService:
+
+    @patch('git_plan.service.git.GitService._run_command')
+    def test_has_staged_files_should_return_true_on_calledprocesserror(self, run_mock: MagicMock):
+        run_mock.side_effect = CalledProcessError(1, 'foo')
+        git = GitService()
+
+        assert git.has_staged_files() == True
+
+    @patch('git_plan.service.git.GitService._run_command')
+    def test_get_current_branch_should_raise_gitexception_on_failure(self, run_mock: MagicMock):
+        run_mock.side_effect = CalledProcessError(1, 'foo')
+        git = GitService()
+
+        with pytest.raises(GitException):
+            git.get_current_branch()
+
+    @patch('git_plan.model.commit.Commit')
+    @patch('git_plan.service.git.GitService._run_command')
+    def test_commit_should_raise_commit_abandoned_on_command_failure(self, run_mock: MagicMock, commit_mock: MagicMock):
+        run_mock.side_effect = CalledProcessError(1, 'foo')
+        git = GitService()
+        commit = MagicMock()
+        commit.message = MagicMock(return_value="foo")
+
+        with pytest.raises(CommitAbandoned):
+            git.commit(commit)
+


### PR DESCRIPTION
What does this PR do?
=========================
* Updates List to take a -b/--branch argument
* Updates plan service to optionally filter commits by branch
* Adds strip() to commit contents and branch name, to ensure we don't have any unwanted whitespace.
* Refactors to satisfy pylint