### PR TITLE
Prints error message when not in git repository

### DIFF
--- a/git_plan/__cli__.py
+++ b/git_plan/__cli__.py
@@ -30,7 +30,7 @@ def main():
     except ProjectNotInitialized:
         print("Git plan is not initialized.\n\tPlease run `git plan init`")
     except NotAGitRepository:
-        print("fatal: not a git repository (or any of the parent directories): .git")
+        print("You are not in a git repository (no .git/ directory found).")
     except GitPlanException as exc:
         print("git plan encountered an error.")
         print("Please open an issue at https://github.com/synek/git-plan and let us know.\n")

--- a/git_plan/__cli__.py
+++ b/git_plan/__cli__.py
@@ -11,24 +11,26 @@ from dependency_injector.wiring import inject, Provide
 from git_plan.cli.cli import CLI
 from git_plan.conf import Settings
 from git_plan.containers import Application
-from git_plan.exceptions import ProjectNotInitialized, GitPlanException
+from git_plan.exceptions import NotAGitRepository, ProjectNotInitialized, GitPlanException
 
 HOME = str(Path.home())
 
 
 def main():
     """Entrypoint"""
-    settings = Settings.load()
-
-    app = Application()
-    app.config.from_dict(settings)
-    app.wire(modules=[sys.modules[__name__]])
-
     try:
+        settings = Settings.load()
+
+        app = Application()
+        app.config.from_dict(settings)
+        app.wire(modules=[sys.modules[__name__]])
+
         args = sys.argv[1:]  # Might be []
         launch_cli(args)
     except ProjectNotInitialized:
         print("Git plan is not initialized.\n\tPlease run `git plan init`")
+    except NotAGitRepository:
+        print("fatal: not a git repository (or any of the parent directories): .git")
     except GitPlanException as exc:
         print("git plan encountered an error.")
         print("Please open an issue at https://github.com/synek/git-plan and let us know.\n")

--- a/git_plan/conf.py
+++ b/git_plan/conf.py
@@ -2,12 +2,9 @@
 
 Author: Rory Byrne <rory@rory.bio>
 """
-import sys
-
 from pathlib import Path
 
 from git_plan import constants
-from git_plan.exceptions import NotAGitRepository
 from git_plan.util.git import get_repository_root
 
 
@@ -44,11 +41,7 @@ class Settings(dict):
         local_settings.update(project_settings)  # Roll project into local settings
         settings.update(local_settings)  # Roll both into the default settings
 
-        try:
-            cwd = Path.cwd()
-            settings["project_root"] = get_repository_root(cwd)
-        except NotAGitRepository:
-            print("fatal: not a git repository (or any of the parent directories): .git")
-            sys.exit()
+        cwd = Path.cwd()
+        settings["project_root"] = get_repository_root(cwd)
 
         return Settings(settings)

--- a/git_plan/conf.py
+++ b/git_plan/conf.py
@@ -2,6 +2,8 @@
 
 Author: Rory Byrne <rory@rory.bio>
 """
+import sys
+
 from pathlib import Path
 
 from git_plan import constants
@@ -45,7 +47,8 @@ class Settings(dict):
         try:
             cwd = Path.cwd()
             settings["project_root"] = get_repository_root(cwd)
-        except NotAGitRepository as exc:
-            raise RuntimeError("Not in a git repository") from exc
+        except NotAGitRepository:
+            print("fatal: not a git repository (or any of the parent directories): .git")
+            sys.exit()
 
         return Settings(settings)


### PR DESCRIPTION
What does this PR do?
Prints the default git message when not in a git repository:
`fatal: not a git repository (or any of the parent directories): .git`

Why are we doing this?
To solve issue #79 and to make it more user-friendly.

Testing performed
- Ran the `tox`command and also the pre-commit tests. All passed ✅
- Ran the `git plan --version` command **which is now** printing the default git error.
- Ran the `gp --version` **which was already** printing the default message.

Known issues
- Had to add `sys.exit()` because the `git plan --version` command was still printing the version even if not inside a git repository.
- I couldn't figure it out why the `gp --version` was not raising the `RuntimeError` exeception.
