### PR TITLE
[#88] List command shows all plans by default, with optional -b to filter for the current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use the tool, run `git plan init` (or simply `gp <command>`) to initialize, a
 * `git plan` - create a new plan, or list existing plans
 * `git plan --version` - print version info
 * `git plan --help` - print help
-* `git plan list [-l/--long] [-a/--all]` - list existing plans
+* `git plan list [-l/--long] [-b/--branch]` - list existing plans
 * `git plan add` - plan a new commit
 * `git plan edit` - edit an existing plan
 * `git plan delete` - delete a plan

--- a/git_plan/cli/commands/list.py
+++ b/git_plan/cli/commands/list.py
@@ -23,16 +23,16 @@ class List(Command):
         self._plan_service = plan_service
         self._git = git_service
 
-    def command(self, *, long: bool = False, branch: str = None, **kwargs):  # pylint: disable=arguments-differ
+    def command(self, *, long: bool = False, branch: bool = None, **kwargs):  # pylint: disable=arguments-differ
         """List the planned commits"""
-        if not branch:
-            branch = self._git.get_current_branch()
-        elif branch == "all":
-            branch = None
+        if branch:
+            filter_branch = self._git.get_current_branch()
+        else:
+            filter_branch = None
 
-        branch_display = branch if branch else "all branches"
+        branch_display = filter_branch if filter_branch else "all branches"
         self._ui.print(f"Plans for [bold]{branch_display}[/bold]\n")
-        commits = self._plan_service.get_commits(self._project, branch=branch)
+        commits = self._plan_service.get_commits(self._project, branch=filter_branch)
 
         if len(commits) == 0:
             if branch:
@@ -48,5 +48,10 @@ class List(Command):
     def register_subparser(self, subparsers: Any):
         parser: ArgumentParser = subparsers.add_parser(List.subcommand, help='List existing commit plans.')
         parser.add_argument('-l', '--long', dest='long', action='store_true')
-        parser.add_argument('-b', '--branch', dest='branch', help="Filter plans for a specific branch")
-        parser.add_argument('-a', '--all', dest='branch', action="store_const", const="all", help="Show all plans")
+        parser.add_argument(
+            '-b',
+            '--branch',
+            dest='branch',
+            action='store_true',
+            help='Show plans for the current branch'
+        )


### PR DESCRIPTION
What does this PR do?
=====================
* Refactors the list command and its arguments, so that all plans are shown by default

Why are we doing this?
======================
* So that `list`/`commit` operate on the same set of plans
* To avoid an annoying situation where you try to see/commit a plan but can't because it's on a different branch

Testing performed
=================
* tox
* Testing manually

Known issues
============
-

Notes
=====
Closes #88
